### PR TITLE
Improve viewpoint and selection

### DIFF
--- a/web/docu-app/packages/sprotty-component/src/di.config.ts
+++ b/web/docu-app/packages/sprotty-component/src/di.config.ts
@@ -102,6 +102,7 @@ export default (containerId: string, withSelectionSupport: boolean) => {
     boundsModule,
     undoRedoModule,
     viewportModule,
+    selectModule,
     fadeModule,
     hoverModule,
     exportModule,

--- a/web/docu-app/packages/sprotty-component/src/wrapper.ts
+++ b/web/docu-app/packages/sprotty-component/src/wrapper.ts
@@ -85,9 +85,9 @@ export class SprottyWrapper extends HTMLElement {
       this._selection.length === selection.length &&
       this._selection.reduce((acc, el, i) => acc && el.id === selection[i], true);
     if (!isSameSelection) {
-      const allSelectableElements = this.allSelectableElements();
-      selection.forEach(element => allSelectableElements.splice(allSelectableElements.indexOf(element)));
-      this.actionDispatcher.dispatchAll([new CenterAction(selection), new SelectAction(selection, allSelectableElements)]);
+      const elementsToDeselect = this.allSelectableElements();
+      selection.forEach(element => elementsToDeselect.splice(elementsToDeselect.indexOf(element), 1));
+      this.actionDispatcher.dispatchAll([new CenterAction(selection), new SelectAction(selection, elementsToDeselect)]);
       this._selection = getIdsToSModelElement(selection, this.root.index);
     }
   }


### PR DESCRIPTION
This PR fixes #21 and fixes #22 and makes use of the action dispatcher instead of directly executing commands on the command stack to avoid bypassing the action handler configuration in sprotty.