### PR TITLE
Fix #25 Table representations sometimes don't have columns

### DIFF
--- a/com.eclipsesource.icat.tooling.annotation/description/project.odesign
+++ b/com.eclipsesource.icat.tooling.annotation/description/project.odesign
@@ -875,5 +875,6 @@
         </create>
       </intersection>
     </ownedRepresentations>
+    <ownedJavaExtensions qualifiedClassName="com.eclipsesource.icat.tooling.annotation.services.DekraServices"/>
   </ownedViewpoints>
 </description:Group>

--- a/com.eclipsesource.icat.tooling.annotation/src/com/eclipsesource/icat/tooling/annotation/services/DekraServices.java
+++ b/com.eclipsesource.icat.tooling.annotation/src/com/eclipsesource/icat/tooling/annotation/services/DekraServices.java
@@ -1,0 +1,16 @@
+package com.eclipsesource.icat.tooling.annotation.services;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+public class DekraServices {
+	/**
+	 * Returns the root container; it may be this object itself
+	 * 
+	 * @param eObject the object to get the root container for.
+	 * @return the root container.
+	 */
+	public EObject getRootContainer(EObject eObject) {
+		return EcoreUtil.getRootContainer(eObject);
+	}
+}


### PR DESCRIPTION
Add missing service extension for "service:getRoot"  used in the .odesign description. Fixes #25 