### PR TITLE
Review of #48

### DIFF
--- a/web/docu-app/packages/docu-react/src/types/index.ts
+++ b/web/docu-app/packages/docu-react/src/types/index.ts
@@ -4,8 +4,11 @@ export interface ENamedElement {
   description?: string
 }
 
-export interface EEnum extends ENamedElement {
-  package: string,
+export interface PackageMember {
+  package: string;
+}
+
+export interface EEnum extends ENamedElement, PackageMember {
   name: string;
   literals: ELiteral[];
 }
@@ -14,39 +17,33 @@ export interface ELiteral extends ENamedElement {
   value: number;
 }
 
-export interface EParameterProps extends ENamedElement{
-  package: string,
+export interface EParameterProps extends ENamedElement, PackageMember {
   type: string,
   name: string;
 }
 
-export interface EDataType extends ENamedElement {
-  package: string,
+export interface EDataType extends ENamedElement, PackageMember {
   type: string;
 }
 
-export interface EAttribute extends ENamedElement {
-  package: string,
+export interface EAttribute extends ENamedElement, PackageMember {
   type: string,
   many: boolean
 }
 
-export interface EReference extends ENamedElement {
-  package: string,
+export interface EReference extends ENamedElement, PackageMember {
   type: string,
   many: boolean
 }
 
-export interface EClass extends ENamedElement {
-  package: string,
+export interface EClass extends ENamedElement, PackageMember {
   superTypes?: string[],
   attributes?: EAttribute[],
   references?: EReference[],
   operations?: EOperation[]
 }
 
-export interface EOperation extends ENamedElement {
-  package: string,
+export interface EOperation extends ENamedElement, PackageMember {
   type: string;
   parameters: EParameterProps[];
   many: boolean

--- a/web/docu-app/packages/docu-react/src/util/index.ts
+++ b/web/docu-app/packages/docu-react/src/util/index.ts
@@ -1,4 +1,4 @@
-import {EClass, EEnum, EPackage, ENamedElement, ELiteral} from "../types";
+import {EClass, EEnum, EPackage, ENamedElement} from "../types";
 
 export const isEClass = (eClassifier: ENamedElement): eClassifier is EClass =>
   eClassifier['attributes'] !== undefined || eClassifier['references'] !== undefined;
@@ -11,17 +11,7 @@ export const isEPackage = (eNamedElement: ENamedElement): eNamedElement is EPack
   eNamedElement['dataTypes'] !== undefined ||
   eNamedElement['enums'] !== undefined;
 
-export const getArrayByName =
-  <T>(pred: (element: ENamedElement) => boolean, propName: string) => (element: ENamedElement): T[] => {
-  if (pred(element)) {
-    return (element[propName] || []);
-  }
-  return []
-};
-
 export const getOrEmpty = <T>(array?: T[]): T[] => array === undefined ? [] : array;
-
-export const getLiterals: ((el: ENamedElement) => ELiteral[]) = getArrayByName(isEEnum, 'literals');
 
 export const makeNamedElement = (name: string): ENamedElement => ({ name });
 
@@ -49,4 +39,3 @@ export const join = <T>(elements: T[], delimiter: T): T[] => {
 
 export const isNonEmpty = (array?: any[]): boolean => array !== undefined && array.length > 0;
 
-export const startCase = (s: string) => s.charAt(0).toUpperCase() + s.substr(1);


### PR DESCRIPTION
In case packages have the same name, only one package is displayed in the docu app. I've added some code to handle that corner case, although the resolution strategy can surely be improved upon. 

A Typescript interface `PackageMember` definition also has been added in order to remove some repetition. Some unused code has been removed.